### PR TITLE
feat: upgrade node runtime to 20.x

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
-        uses: actions/setup-node@v3
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
   updatedDependencies:
     description: "JSON representing the updated dependencies"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Upgrading node runtime action to v20, as v16 is deprecated. This comes with a 
change an upgrade for gh setup-node action.
