### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## About
 
 GitHub action to update system dependencies installed in a Dockerfile.
-This action currently supports [alpine](https://hub.docker.com/_/alpine) and [debian](https://hub.docker.com/_/debian) images.
+This action currently supports apk and apt based images.
 
 ## Usage
 


### PR DESCRIPTION
we no longer rely on the paradigm of alpine or deb images, instead we support individual pkg managers.