### PR TITLE
fix: support multi stage dockerfiles

### DIFF
--- a/__tests__/data/Dockerfile.multi
+++ b/__tests__/data/Dockerfile.multi
@@ -1,0 +1,5 @@
+# We refer to the base image in the FROM instruction
+FROM ubuntu:latest
+
+# We ignore subsequent FROM instructions
+FROM alpine:latest

--- a/__tests__/dockerfile.test.ts
+++ b/__tests__/dockerfile.test.ts
@@ -22,3 +22,10 @@ test('load dockerfile with unsupported package manager', async () => {
     'Unable to find supported package manager'
   )
 }, 10000)
+
+test('load multi stage dockerfile', async () => {
+  const dockerfilePath = path.join(__dirname, 'data', 'Dockerfile.multi')
+  const dockerfile = await load(dockerfilePath)
+  expect(dockerfile.pkgManager).toBe('apt')
+  expect(dockerfile.name).toBe('ubuntu:latest')
+})

--- a/src/dockerfile.ts
+++ b/src/dockerfile.ts
@@ -18,6 +18,7 @@ function extract_docker_image(dockerfile_content: string): image.Image {
   for (const line of dockerfileLines) {
     if (line.includes('FROM')) {
       imageName = line.split(' ')[1].trim()
+      break
     }
   }
   return new image.Image(imageName)


### PR DESCRIPTION
This PR provides support for multistage dockerfiles with multiple `FROM` statements. We opt to only decipher the package manager from the 
first instruction.
