### PR TITLE
chore: prepare release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2023-12-21
+
+### Fixed
+
+- detect package manager from first step (in multisteps dockerfiles)
+
+## [2.0.0] - 2023-12-05
+
+### Changed
+
+- support any image name: auto detect package manager
+- upgrade node runtime to 20.x
+
 ## [1.0.1] - 2022-07-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-dependency-updater",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "license": "Apache-2.0",
   "description": "",
   "main": "lib/main.js",


### PR DESCRIPTION
## Rationale

Rollout the recent fix.
Also update the changelog, we forgot this step on previous release.