### PR TITLE
tests: adjust timeout of dockerfile tests

### DIFF
--- a/__tests__/dockerfile.test.ts
+++ b/__tests__/dockerfile.test.ts
@@ -10,21 +10,21 @@ test('load alpine dockerfile', async () => {
   const dockerfile = await load(dockerfilePath)
   expect(dockerfile.pkgManager).toBe('apk')
   expect(dockerfile.name).toBe('alpine:latest')
-}, 10000)
+}, 60000)
 
 test('load ubuntu dockerfile', async () => {
   const dockerfilePath = path.join(__dirname, 'data', 'Dockerfile.apt')
   const dockerfile = await load(dockerfilePath)
   expect(dockerfile.pkgManager).toBe('apt')
   expect(dockerfile.name).toBe('ubuntu:latest')
-}, 10000)
+}, 60000)
 
 test('load dockerfile with unsupported package manager', async () => {
   const dockerfilePath = path.join(__dirname, 'data', 'Dockerfile.unsupported')
   await expect(load(dockerfilePath)).rejects.toThrow(
     'Unable to find supported package manager'
   )
-}, 10000)
+}, 60000)
 
 test('load multi stage dockerfile', async () => {
   const dockerfilePath = path.join(__dirname, 'data', 'Dockerfile.multi')


### PR DESCRIPTION
These tests are often failing to complete within the allowed timeframe
in the CI, giving it more time should solve the issue.
