### PR TITLE
ci: make sure that the CI checks file format

### DIFF
--- a/__tests__/dockerfile.test.ts
+++ b/__tests__/dockerfile.test.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@jest/globals'
 import * as path from 'path'
-import { fileURLToPath } from 'url'
+import {fileURLToPath} from 'url'
 import {load} from '../src/dockerfile.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -2,7 +2,7 @@ import * as process from 'process'
 import * as cp from 'child_process'
 import * as path from 'path'
 import {test} from '@jest/globals'
-import { fileURLToPath } from 'url'
+import {fileURLToPath} from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint src/**/*.ts",
     "package": "ncc build --source-map",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
+    "all": "npm run build && npm run format-check && npm run lint && npm run package && npm test"
   },
   "engines": {
     "node": ">=24.0.0 <25.0.0"


### PR DESCRIPTION
Our CI will now fail if prettier was not executed on the repository
files.
