### PR TITLE
docs: prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [3.0.0] - 2026-04-29
+
+### Added
+
+- CI now enforces file format checks (#552)
+
+### Changed
+
+- Migrated codebase to ESM modules (#545)
+- Updated Node.js runtime to Node 24 (#546)
+- Minor code improvements for more idiomatic TypeScript/JavaScript (#553)
+
+### Security
+
+- Improved dependencies security posture (#547)
+- Bumped dependencies to address Dependabot security advisories (#551)
+- Updated all dependencies to their latest available versions (#544)
+
+
 ## [2.0.5] - 2024-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Note the `workflow_dispatch` trigger that will enable you to run this workflow i
 | `dependencies` | String | Path to the dependencies.json file where you keep your dependencies pinned |
 | `apply`        | Bool   | If true the action will apply changes directly to the files checked out |
 
+### Action outputs
+
+| Name                   | Type   | Description |
+| ---                    | ---    | ---         |
+| `updatedDependencies`  | String | JSON representing the updated dependencies |
+
 ## Recommendations
 
 Before using this Action you will need to update your Dockerfile in order to extract the dependencies you install.


### PR DESCRIPTION
This change updates the CHANGELOG for a release of the Github Action as
well as the README.
